### PR TITLE
Update Chapter 9: Complete Architecture Decisions with ADRs 004 and 005

### DIFF
--- a/docs/arc42/src/09_architecture_decisions.adoc
+++ b/docs/arc42/src/09_architecture_decisions.adoc
@@ -36,7 +36,7 @@ There you will find links and examples about ADR.
 ****
 endif::arc42help[]
 
-This section references the Architecture Decision Records (ADRs) that document key technical decisions for the UART2ETH project.
+This section references the Architecture Decision Records (ADRs) that document key technical decisions for the UART2ETH project. These decisions form the foundation of the system architecture and significantly influence capabilities, performance characteristics, and development approach.
 
 === Hardware Platform Decisions
 
@@ -46,5 +46,20 @@ This section references the Architecture Decision Records (ADRs) that document k
 === Software Platform Decisions
 
 * link:../../adrs/ADR-003-programming-language-selection.adoc[ADR-003: Programming Language Selection] - Documents the decision to use C programming language for firmware development, considering team expertise, delivery timeline, and memory model constraints.
+* link:../../adrs/ADR-004-development-ecosystem.adoc[ADR-004: Development Ecosystem Selection] - Documents the decision to use Native Pico SDK + CMake development ecosystem for professional, industrial-grade development.
 
-These decisions form the foundation of the hardware and software architecture and significantly influence the system's capabilities, performance characteristics, and development approach.
+=== Implementation Strategy Decisions
+
+* link:../../adrs/ADR-005-buffer-allocation-strategy.adoc[ADR-005: Ring Buffer Memory Allocation Strategy] - Documents the decision to use static worst-case allocation for inter-core communication buffers, prioritizing reliability and determinism over memory efficiency.
+
+=== Decision Interdependencies
+
+The ADRs reveal important interdependencies that influence architectural coherence:
+
+* *ADR-004 (Development Ecosystem) challenges ADR-002 (Ethernet Controller)*: The ecosystem analysis revealed that ENC28J60 lacks mature RP2350 SDK integration, potentially requiring significant custom development effort and impacting industrial reliability goals.
+
+* *ADR-003 (C Language) reinforces ADR-004 (Native SDK)*: The choice of C programming language aligns optimally with the Native Pico SDK approach, enabling direct application of team expertise.
+
+* *ADR-005 (Buffer Strategy) supports ADR-003 (C Language)*: Static allocation strategy leverages C's deterministic memory model and supports industrial reliability requirements.
+
+These interdependencies demonstrate the systemic nature of architectural decisions and highlight areas requiring ongoing technical evaluation.


### PR DESCRIPTION
## Summary

Updates Chapter 9 (Architecture Decisions) to include all existing ADRs and document critical decision interdependencies.

## Changes Made

### Added Missing ADRs
- **ADR-004: Development Ecosystem Selection** - Native Pico SDK + CMake approach for professional development
- **ADR-005: Ring Buffer Memory Allocation Strategy** - Static worst-case allocation prioritizing reliability over efficiency

### Improved Organization
- Reorganized ADRs into logical categories:
  - Hardware Platform Decisions (ADR-001, ADR-002)
  - Software Platform Decisions (ADR-003, ADR-004)  
  - Implementation Strategy Decisions (ADR-005)

### Critical Issue Documentation
- **Decision Interdependencies section** highlighting that ADR-004 research challenges ADR-002
- Documents ecosystem maturity concerns with ENC28J60 lacking RP2350 SDK support
- Shows how decisions reinforce each other (C language + Native SDK + Static allocation)

## Technical Impact

This update reveals an important technical issue: **ADR-004's ecosystem analysis suggests ADR-002 (ENC28J60 selection) may need reconsideration** due to:
- No official RP2350 support
- Limited ecosystem maturity 
- Potential significant custom development effort
- Industrial reliability concerns

## Files Changed
- `docs/arc42/src/09_architecture_decisions.adoc` - Updated with complete ADR catalog and interdependencies

## Review Focus Areas
- [ ] Accuracy of ADR descriptions and categorization
- [ ] Clarity of decision interdependency documentation  
- [ ] Assessment of ADR-002/ADR-004 conflict implications
- [ ] Completeness of architectural decision coverage

This brings Chapter 9 up to date with all current architectural decisions and provides stakeholders a complete view of our technical choices and their relationships.