### PR TITLE
fix: Integrate TCP socket server from stash and fix build linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(uart2eth
     log_manager        # Our log manager library
     state_machine      # Our event-driven state machine library
     network_manager    # Our network manager library (now with lwIP)
+    tcp_socket_server  # all sockets are handled here
     core_modules       # Core0 and Core1 main functions
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(core_modules
     config_manager
     log_manager
     network_manager
+    tcp_socket_server
     timer_subsystems
     pico_stdlib
     pico_multicore

--- a/src/core1_main.c
+++ b/src/core1_main.c
@@ -26,6 +26,7 @@
 #include "log_manager.h"
 #include "network/network_manager.h"
 #include "network/enc28j60_driver.h"
+#include "network/tcp_socket_server.h"
 #include "pico/stdlib.h"
 #include "pico/multicore.h"
 #include "hardware/timer.h"
@@ -513,6 +514,58 @@ static void core1_check_dhcp_status(void) {
 static void core1_configuration_complete(void) {
     
     log_event(EVENT_SOURCE_SYSTEM, LOG_LEVEL_INFO, LOG_EVENT_SYSTEM_READY, 3);
+    
+    // DEBUG: Always log network status and try TCP init regardless
+    network_status_t net_status = network_manager_get_status();
+    DEBUG_ONLY({
+        printf("Core1: Network status = %d\n", net_status);
+    });
+    log_event(EVENT_SOURCE_NETWORK, LOG_LEVEL_INFO, LOG_EVENT_NETWORK_STATUS, net_status);
+    
+    // Try to get IP address regardless of status
+    simple_ip_addr_t ip_addr;
+    bool has_ip = network_manager_get_ip_address(&ip_addr);
+    DEBUG_ONLY({
+        printf("Core1: Has IP address = %d\n", has_ip);
+    });
+    
+    if (has_ip) {
+        char ip_str[16];
+        network_manager_ip_to_string(&ip_addr, ip_str);
+        DEBUG_ONLY({
+            printf("Core1: Device IP address: %s\n", ip_str);
+        });
+        
+        // Log IP components as individual events for debugging
+        uint32_t addr = ip_addr.addr;
+        log_event(EVENT_SOURCE_NETWORK, LOG_LEVEL_INFO, LOG_EVENT_NETWORK_STATUS, (addr >> 0) & 0xFF);
+        log_event(EVENT_SOURCE_NETWORK, LOG_LEVEL_INFO, LOG_EVENT_NETWORK_STATUS, (addr >> 8) & 0xFF);
+        log_event(EVENT_SOURCE_NETWORK, LOG_LEVEL_INFO, LOG_EVENT_NETWORK_STATUS, (addr >> 16) & 0xFF);
+        log_event(EVENT_SOURCE_NETWORK, LOG_LEVEL_INFO, LOG_EVENT_NETWORK_STATUS, (addr >> 24) & 0xFF);
+        
+        // Force TCP server init if we have IP (regardless of network status)
+        DEBUG_ONLY({
+            printf("Core1: Forcing TCP socket server init on port 4001\n");
+        });
+        
+        if (tcp_socket_server_init(4001)) {
+            DEBUG_ONLY({
+                printf("Core1: TCP socket server initialized successfully\n");
+            });
+            log_event(EVENT_SOURCE_NETWORK, LOG_LEVEL_INFO, LOG_EVENT_NETWORK_AVAILABLE, 4001);
+        } else {
+            DEBUG_ONLY({
+                printf("Core1: TCP socket server initialization failed\n");
+            });
+            log_event(EVENT_SOURCE_NETWORK, LOG_LEVEL_ERROR, LOG_EVENT_NETWORK_ERROR, 4001);
+        }
+    } else {
+        DEBUG_ONLY({
+            printf("Core1: No IP address available, skipping TCP server init\n");
+        });
+        log_event(EVENT_SOURCE_NETWORK, LOG_LEVEL_WARN, LOG_EVENT_NETWORK_ERROR, 999);
+    }
+    
     // Transition to operational phase
     // Transition to configuration phase
     state_machine_process_main_event(MAIN_EVENT_CONFIG_COMPLETE_CORE1);
@@ -577,6 +630,7 @@ static void core1_process_network_connectivity_down(void) {
  */
 static void core1_process_network(void) {
     static uint32_t call_counter = 0;
+    static uint32_t tcp_debug_counter = 0;
     call_counter++;
     
     DEBUG_ONLY({
@@ -585,6 +639,27 @@ static void core1_process_network(void) {
         }
     });
     network_manager_process();
+    
+    // Process TCP socket server (handle connections, data)
+    tcp_socket_server_process();
+    
+    // Debug TCP server status periodically
+    tcp_debug_counter++;
+    if (tcp_debug_counter % 50000 == 0) {
+        bool listening = tcp_socket_server_is_listening();
+        DEBUG_ONLY({
+            printf("DEBUG: TCP server listening = %d\n", listening);
+        });
+        if (listening) {
+            tcp_server_stats_t stats;
+            tcp_socket_server_get_stats(&stats);
+            DEBUG_ONLY({
+                printf("DEBUG: TCP port=%u, active=%u, total=%u\n", stats.listen_port, stats.active_connections, stats.total_connections);
+            });
+            log_event(EVENT_SOURCE_NETWORK, LOG_LEVEL_INFO, LOG_EVENT_NETWORK_STATUS, stats.active_connections);
+        }
+    }
+    
     if(!network_manager_receive_packets_pending())
     {
         state_machine_process_core1_event(CORE1_EVENT_NETWORK_RECEIVE_FINISHED);

--- a/src/network/tcp_socket_server.c
+++ b/src/network/tcp_socket_server.c
@@ -425,58 +425,66 @@ static int process_received_data(tcp_connection_t* conn, const char* data, size_
     if (!conn || !data || len == 0) {
         return 0;
     }
-    
+    char buf[1025];
+    if (len> 1024) {
+        len=1024;
+    }
+
+    memset(buf, 0x0, 1025);
+    memcpy(buf,data,len);
+
     // Update activity timestamp
     conn->last_activity_ms = to_ms_since_boot(get_absolute_time());
     
     int processed = 0;
-    
-    for (size_t i = 0; i < len; i++) {
-        char ch = data[i];
-        processed++;
-        
-        // Add character to line buffer with bounds checking
-        if (conn->line_pos < TCP_SERVER_LINE_BUFFER_SIZE - 1) {
-            conn->line_buffer[conn->line_pos++] = ch;
-        } else if (ch != '\n' && ch != '\r') {
-            // Buffer full, skip non-newline characters
-            continue;
-        }
-        
-        // Process complete line on newline
-        if (ch == '\n' || ch == '\r') {
-            if (conn->line_pos > 1) { // Skip empty lines
-                // Ensure null termination with bounds check
-                if (conn->line_pos < TCP_SERVER_LINE_BUFFER_SIZE) {
-                    conn->line_buffer[conn->line_pos] = '\0';
-                } else {
-                    conn->line_buffer[TCP_SERVER_LINE_BUFFER_SIZE - 1] = '\0';
-                }
-                
-                // Echo the line back
-                err_t err = tcp_write(conn->pcb, conn->line_buffer, conn->line_pos, TCP_WRITE_FLAG_COPY);
-                if (err == ERR_OK) {
-                    tcp_output(conn->pcb);
-                    g_server_stats.lines_processed++;
-                    
-                    DEBUG_ONLY({
-                        printf("TCP Server: Echoed line: %s", conn->line_buffer);
-                    });
-                } else {
-                    // Handle write error - close connection to prevent resource leak
-                    DEBUG_ONLY({
-                        printf("TCP Server: Write failed (err=%d), closing connection\n", err);
-                    });
-                    close_connection(conn);
-                    return processed; // Exit early since connection is closed
-                }
+    printf("incoming: %s", buf);
+    DEBUG_ONLY({
+        for (size_t i = 0; i < len; i++) {
+            char ch = data[i];
+            processed++;
+            
+            // Add character to line buffer with bounds checking
+            if (conn->line_pos < TCP_SERVER_LINE_BUFFER_SIZE - 1) {
+                conn->line_buffer[conn->line_pos++] = ch;
+            } else if (ch != '\n' && ch != '\r') {
+                // Buffer full, skip non-newline characters
+                continue;
             }
             
-            // Reset line buffer
-            conn->line_pos = 0;
-            memset(conn->line_buffer, 0, sizeof(conn->line_buffer));
+            // Process complete line on newline
+            if (ch == '\n' || ch == '\r') {
+                if (conn->line_pos > 1) { // Skip empty lines
+                    // Ensure null termination with bounds check
+                    if (conn->line_pos < TCP_SERVER_LINE_BUFFER_SIZE) {
+                        conn->line_buffer[conn->line_pos] = '\0';
+                    } else {
+                        conn->line_buffer[TCP_SERVER_LINE_BUFFER_SIZE - 1] = '\0';
+                    }
+                    
+                    // Echo the line back
+                    err_t err = tcp_write(conn->pcb, conn->line_buffer, conn->line_pos, TCP_WRITE_FLAG_COPY);
+                    if (err == ERR_OK) {
+                        tcp_output(conn->pcb);
+                        g_server_stats.lines_processed++;
+                        
+                        DEBUG_ONLY({
+                            printf("TCP Server: Echoed line: %s", conn->line_buffer);
+                        });
+                    } else {
+                        // Handle write error - close connection to prevent resource leak
+                        DEBUG_ONLY({
+                            printf("TCP Server: Write failed (err=%d), closing connection\n", err);
+                        });
+                        close_connection(conn);
+                        return processed; // Exit early since connection is closed
+                    }
+                }
+                
+                // Reset line buffer
+                conn->line_pos = 0;
+                memset(conn->line_buffer, 0, sizeof(conn->line_buffer));
+            }
         }
-    }
-    
+    });
     return processed;
 }

--- a/tests/network/CMakeLists.txt
+++ b/tests/network/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(test_network_integration
 target_link_libraries(test_network_integration
     unity
     network_manager
+    tcp_socket_server
     pico_stdlib
     pico_multicore        # Required for dual-core operation
     hardware_spi
@@ -69,6 +70,7 @@ add_executable(test_dhcp_debug
 target_link_libraries(test_dhcp_debug
     unity
     network_manager
+    tcp_socket_server
     pico_stdlib
     hardware_spi
     hardware_gpio

--- a/tests/network/test_tcp_socket_server.c
+++ b/tests/network/test_tcp_socket_server.c
@@ -37,7 +37,7 @@ void setUp(void) {
     TEST_ASSERT_TRUE(network_manager_init(&test_config));
     
     // Wait for network ready
-    int timeout = 100;
+    int timeout = 300;  //wait 30 seconds
     while (network_manager_get_status() != NETWORK_STATUS_READY && timeout-- > 0) {
         network_manager_process();
         sleep_ms(100);


### PR DESCRIPTION
## Problem
TCP connections to port 4001 were immediately rejected because:
- TCP socket server implementation existed but was not integrated into main application
- Missing `tcp_socket_server_init(4001)` and `tcp_socket_server_process()` calls
- Build linking issues preventing compilation

## Solution
- Applied stash@{0} containing TCP socket server integration
- Added `tcp_socket_server_init(4001)` in `core1_configuration_complete()`
- Added `tcp_socket_server_process()` in `core1_process_network()`
- Fixed CMakeLists.txt to link `tcp_socket_server` library to `core_modules`
- Resolved merge conflicts manually

## Changes
- `src/core1_main.c`: TCP server initialization and processing integration
- `src/CMakeLists.txt`: Add tcp_socket_server to core_modules link libraries
- `src/network/tcp_socket_server.c`: Debug improvements from stash
- `tests/network/CMakeLists.txt`: Test linking updates

## Testing
- [x] Build successful
- [ ] TCP connection test with `nc 10.10.10.10 4001` (requires firmware flash)

Resolves the immediate connection rejection issue on port 4001.