### PR TITLE
Update ENC28J60 interrupt pin configuration

### DIFF
--- a/include/network/enc28j60_driver.h
+++ b/include/network/enc28j60_driver.h
@@ -28,12 +28,12 @@ extern "C" {
 #endif
 
 // Hardware pin configuration
-#define ENC28J60_RESET_PIN      3 //14
-#define ENC28J60_INTERRUPT_PIN  8
-#define ENC28J60_SCK_PIN        10 //2
-#define ENC28J60_MOSI_PIN       11 //3   // SI - Serial Input
-#define ENC28J60_MISO_PIN       12 //4   // SO - Serial Output  
-#define ENC28J60_CS_PIN         13 //5
+#define ENC28J60_RESET_PIN      3 
+#define ENC28J60_INTERRUPT_PIN  2
+#define ENC28J60_SCK_PIN        10 
+#define ENC28J60_MOSI_PIN       11    
+#define ENC28J60_MISO_PIN       12      
+#define ENC28J60_CS_PIN         13 
 
 // Register Bank definitions
 #define ENC28J60_BANK0          0x00


### PR DESCRIPTION
## Summary
Updates the ENC28J60 Ethernet controller interrupt pin configuration to align with the actual hardware board layout.

## Changes Made
- **Pin Configuration Update**: Changed `ENC28J60_INTERRUPT_PIN` from pin 8 to pin 2
- **Code Cleanup**: Removed inline comments for cleaner code readability
- **Hardware Alignment**: Ensures firmware matches the actual board pin assignments

## Technical Details
This change updates the hardware pin definitions in `include/network/enc28j60_driver.h` to reflect the correct interrupt pin assignment for the ENC28J60 Ethernet controller. The interrupt pin is critical for proper network operation as it signals when the controller has data ready or needs attention.

## Testing Impact
- Existing functionality should remain unchanged except for proper interrupt handling
- Network operations may become more reliable with correct pin assignment
- No breaking changes to the API or protocol implementation

## Files Changed
- `include/network/enc28j60_driver.h`: Updated pin configuration constants

This is a small but important hardware configuration fix that ensures the firmware correctly interfaces with the physical board layout.