### PR TITLE
Document current pin configuration in ADR-008

### DIFF
--- a/src/docs/arc42/adrs/ADR-008-hardware-pin-configuration.adoc
+++ b/src/docs/arc42/adrs/ADR-008-hardware-pin-configuration.adoc
@@ -1,4 +1,4 @@
-:jbake-title: ADR-008: Hardware Pin Configuration Update
+:jbake-title: ADR-008: Hardware Pin Configuration
 :jbake-type: page_toc
 :jbake-status: published
 :jbake-menu: arc42
@@ -9,148 +9,148 @@ ifndef::imagesdir[:imagesdir: ../../images]
 :toc:
 
 [[section-adr-008-hardware-pin-configuration]]
-== ADR-008: Hardware Pin Configuration Update
+== ADR-008: Hardware Pin Configuration
 
 **Status:** Accepted
 
-**Date:** 2025-08-10
+**Date:** 2025-08-27
 
-**Context:** The original hardware pin configuration used SPI0 for the ENC28J60 Ethernet controller and UART1 for debug output. A hardware redesign requires updating the pin configuration to optimize board layout and improve signal routing.
+**Context:** This document defines the current hardware pin configuration for the UART2ETH device based on RP2350. The configuration supports up to 4 UART channels exposed as TCP sockets, with dedicated pins for Ethernet communication and system debugging.
 
-=== Decision
+=== Current Pin Configuration
 
-We will update the hardware pin configuration to use SPI1 for the ENC28J60 Ethernet controller and UART0 for debug output, with the addition of a dedicated reset pin for enhanced hardware control.
+The RP2350 pin assignment is optimized for PCB layout efficiency and signal integrity. The configuration supports up to 4 UART channels exposed as TCP sockets, with dedicated pins for Ethernet communication and system debugging.
 
-==== New Pin Configuration
+==== Complete Pin Mapping
 
-[cols="2,2,3,3"]
+[cols="3,2,3,4"]
 |===
-|Function |Pin |Previous |Notes
+|Function |GPIO Pin |Interface |Description
 
-|UART0 TX |GP0 |N/A (was on UART1) |Debug output (115200 baud)
-|UART0 RX |GP1 |N/A (was on UART1) |Debug input (115200 baud)
-|ENC-RESET |GP3 |N/A |New dedicated reset pin for ENC28J60
-|ENC-INTERRUPT |GP2 |GP14 |ENC28J60 interrupt signal (active low)
-|ENC-SCK |GP10 |GP2 |SPI1 clock signal
-|ENC-SI (MOSI) |GP11 |GP3 |SPI1 serial input to ENC28J60
-|ENC-SO (MISO) |GP12 |GP4 |SPI1 serial output from ENC28J60
-|ENC-CSn |GP13 |GP5 |SPI1 chip select (active low)
-|===
+|**Debug Interface**
+|Debug TX |GP0 |UART0 |Printf debug output via USB-CDC (/dev/ttyACM0) at 115200 baud
+|Debug RX |GP1 |UART0 |Debug input (currently disabled for applications)
 
-==== Major Changes
+|**UART Channels**
+|Channel 1 TX |GP4 |UART1 |UART Channel 1 transmit (active, 115200 baud)
+|Channel 1 RX |GP5 |UART1 |UART Channel 1 receive (active, 115200 baud)
+|Channel 2 TX |GP4 |PIO |UART Channel 2 transmit (reserved, disabled)
+|Channel 2 RX |GP5 |PIO |UART Channel 2 receive (reserved, disabled)
+|Channel 3 TX |GP6 |PIO |UART Channel 3 transmit (reserved, disabled)
+|Channel 3 RX |GP7 |PIO |UART Channel 3 receive (reserved, disabled)
 
-1. **SPI Interface Change**: ENC28J60 moves from SPI0 to SPI1
-   - SCK: GP2 → GP10
-   - MOSI: GP3 → GP11  
-   - MISO: GP4 → GP12
-   - CS: GP5 → GP13
-
-2. **Debug UART Change**: Debug output moves from UART1 to UART0
-   - TX: GP20 → GP0
-   - RX: GP21 → GP1
-
-3. **Reset Pin Addition**: Dedicated reset control for ENC28J60
-   - New pin: GP2 for ENC-RESET
-
-4. **Interrupt Pin Change**: ENC28J60 interrupt signal  
-   - INT: GP14 → GP8
-
-=== Rationale
-
-==== Hardware Design Benefits
-
-* **Improved Board Layout**: SPI1 pins (GP10-GP13) are physically adjacent, enabling more compact PCB routing
-* **Signal Integrity**: Shorter traces for high-frequency SPI signals reduce noise and electromagnetic interference
-* **Reset Control**: Dedicated reset pin provides reliable hardware reset capability for ENC28J60 initialization
-* **Debug Accessibility**: UART0 on GP0/GP1 provides easier access for debug connections
-
-==== Software Architecture Benefits
-
-* **Interface Consistency**: SPI1 pins are grouped together in the RP2350 peripheral mapping
-* **Hardware Debugging**: UART0 is typically the primary debug interface on RP2350-based systems
-* **Reset Reliability**: Software-controlled reset eliminates dependency on power-on reset timing
-
-==== Manufacturing Benefits
-
-* **Component Placement**: More efficient component placement on the PCB
-* **Testing Access**: Easier access to debug pins during manufacturing test procedures
-* **Cost Reduction**: Optimized routing may reduce PCB layer count requirements
-
-=== Implementation Impact
-
-==== Driver Changes Required
-
-[cols="2,4,2"]
-|===
-|Component |Required Changes |Test Impact
-
-|`enc28j60_driver.h` |Update pin definitions: `ENC28J60_*_PIN` constants |Unit tests
-|`enc28j60_driver.c` |Change SPI port from `spi0` to `spi1`, add reset pin initialization |Integration tests
-|`test_network_integration.c` |Update debug UART from UART1 to UART0 |Functional tests
-|Hardware documentation |Update pin mapping diagrams and connection specifications |Documentation
+|**Ethernet Controller (ENC28J60)**
+|ENC-MISO |GP8 |SPI |Master In Slave Out
+|ENC-CS |GP9 |SPI |Chip select (active low)
+|ENC-SCK |GP10 |SPI |SPI clock signal
+|ENC-MOSI |GP11 |SPI |Master Out Slave In
+|ENC-RESET |GP12 |Digital Output |Hardware reset control
+|ENC-INTERRUPT |GP13 |Digital Input |Interrupt signal (active low)
 |===
 
-==== Testing Strategy
+==== UART Channel Configuration
 
-1. **Hardware Verification**: Verify SPI1 communication with ENC28J60 using oscilloscope
-2. **Reset Function Testing**: Verify software-controlled reset pin operation  
-3. **Debug UART Testing**: Confirm UART0 debug output functionality
-4. **Network Integration Testing**: Run complete network stack tests with new pin configuration
-5. **Signal Quality Testing**: Verify signal integrity with shorter SPI traces
+[cols="2,2,2,2,2,3"]
+|===
+|Channel |Interface |TX Pin |RX Pin |Baud Rate |Status
 
-==== Compatibility Considerations
+|Channel 0 |UART0/PL011 |GP0 |GP1 |230400 |**Reserved** (debug interface only)
+|Channel 1 |UART1/PL011 |GP4 |GP5 |115200 |**Enabled** (active TCP-to-UART bridge)
+|Channel 2 |PIO |GP4 |GP5 |230400 |**Disabled** (future expansion, shares pins with Channel 1)
+|Channel 3 |PIO |GP6 |GP7 |230400 |**Disabled** (future expansion)
+|===
 
-* **Breaking Change**: This is a breaking hardware change requiring PCB revision
-* **Firmware Compatibility**: Firmware compiled for old pin configuration will not work with new hardware
-* **Development Tool Update**: Hardware debugger connections must be updated for new UART0 debug interface
+==== Interface Details
 
-=== Implementation Plan
+===== Debug Interface (UART0)
+- **Purpose**: System debug output and printf logging
+- **Configuration**: 115200 baud, 8N1, no flow control  
+- **Access**: Available via USB-CDC interface as /dev/ttyACM0
+- **Usage**: Core system logging, boot messages, diagnostic output
+- **Status**: Reserved for debugging, not available for application use
 
-==== Phase 1: Documentation Update
-1. Update ADR-008 (this document) with complete pin mapping
-2. Update Chapter 05 Building Block View with new hardware interface specifications
-3. Update any hardware interface diagrams
+===== Active UART Channel (Channel 1)
+- **Purpose**: Primary TCP-to-UART bridge functionality
+- **Configuration**: 115200 baud, 8N1, no flow control
+- **TCP Port**: Exposed as TCP socket for network access
+- **Protocol**: Custom message framing with '!\r\n' terminators
+- **Hardware**: Uses UART1 hardware peripheral for reliable operation
 
-==== Phase 2: Driver Implementation
-1. Update pin definitions in `enc28j60_driver.h`
-2. Modify SPI initialization and reset pin handling in `enc28j60_driver.c`  
-3. Update test files to use UART0 for debug output
-4. Add reset pin control functions
+===== Ethernet Controller (ENC28J60)
+- **Interface**: SPI communication for Ethernet packet processing
+- **Reset Control**: Software-controlled hardware reset via GP12
+- **Interrupt**: Packet reception and link status notifications via GP13
+- **Buffer**: 8KB total (4KB RX, 4KB TX)
+- **Pin Configuration**: Custom SPI pin mapping optimized for PCB layout
 
-==== Phase 3: Testing and Validation
-1. Hardware bring-up testing with new pin configuration
-2. Run complete test suite to verify functionality
-3. Performance testing to ensure no degradation
-4. Hardware validation with signal integrity measurements
+===== Future Expansion (Channels 2-3)
+- **Implementation**: Reserved for PIO-based UART implementation
+- **Status**: Hardware pins reserved, software implementation pending
+- **Channel 2**: Shares pins GP4/GP5 with Channel 1 (alternative configuration)
+- **Channel 3**: Independent pins GP6/GP7 ready for implementation
+- **Potential**: Up to 4 total UART channels as originally specified
 
-=== Alternatives Considered
+=== Hardware Design Benefits
 
-==== Alternative 1: Keep Current Pin Configuration
-* **Pros**: No software changes required, existing hardware continues to work
-* **Cons**: Suboptimal PCB layout, missed opportunity for hardware improvements
+==== SPI Interface Optimization
+* **Custom Pin Mapping**: ENC28J60 uses custom SPI pin assignment for optimal PCB routing
+* **Signal Integrity**: Pin selection minimizes trace lengths and reduces EMI
+* **Interrupt Handling**: Dedicated interrupt pin enables efficient packet processing
 
-==== Alternative 2: Use Different SPI Port Assignment
-* **Pros**: Different pin groupings might be available
-* **Cons**: SPI1 GP10-GP13 grouping is optimal for PCB layout
+==== UART Interface Distribution  
+* **Separation of Concerns**: Debug UART (UART0) separate from application UARTs
+* **Hardware UART Usage**: Channel 1 uses UART1 hardware for reliable high-speed operation
+* **PIO Expansion**: Channels 2-3 reserved for PIO implementation enabling additional UART channels
+* **Pin Sharing**: Channel 2 can share pins with Channel 1 for alternative configurations
 
-==== Alternative 3: Keep UART1 for Debug
-* **Pros**: No change to existing debug interface
-* **Cons**: UART0 is more standard for primary debug interface on RP2350
-
-=== Decision Outcome
-
-The pin configuration update provides significant hardware design benefits with manageable software implementation complexity. The change aligns with industry best practices for RP2350-based designs and enables more efficient PCB manufacturing.
-
-=== References
-
-* RP2350 Datasheet: GPIO Pin Functions and SPI Interface Specifications
-* ENC28J60 Datasheet: SPI Interface Requirements and Reset Pin Specifications  
-* ADR-001: Microcontroller Platform Selection (RP2350 selection rationale)
-* ADR-002: Ethernet Controller Selection (ENC28J60 selection rationale)
+==== Debug and Development
+* **Standard Debug Interface**: UART0 on GP0/GP1 follows RP2350 conventions
+* **USB-CDC Integration**: Seamless debug access via USB connection without external UART adapter
+* **Manufacturing Support**: Easy access to debug pins during production testing
+* **Development Tools**: Compatible with VS Code Pico extension and OpenOCD debugging
 
 === Implementation Notes
 
-* All pin changes must be implemented atomically to prevent hardware/software mismatch
-* Hardware documentation must be updated before hardware production
-* Test procedures must be validated with new pin configuration before production deployment
-* Development team must be notified of debug interface change (UART1 → UART0)
+==== Driver Configuration
+* **ENC28J60 Driver**: Pin definitions in `include/network/enc28j60_driver.h` lines 31-36
+* **UART Manager**: Channel configurations in `src/uart/uart_manager.c` lines 46-55  
+* **Debug Output**: Configured in CMakeLists.txt with both USB-CDC and UART0 enabled
+* **SPI Configuration**: Custom pin mapping requires manual SPI initialization
+
+==== Development Environment
+* **Flashing**: Uses OpenOCD with CMSIS-DAP interface via VS Code extension
+* **Debugging**: GDB multiarch with OpenOCD server on port 3333
+* **Serial Logging**: Persistent UART logger monitors /dev/ttyACM0 for debug output
+* **Build System**: CMAKE with Pico SDK 2.2.0+ supporting RP2350 target
+
+==== Testing Considerations
+* **Hardware Verification**: All interfaces tested during firmware flashing process
+* **Signal Quality**: Custom SPI configuration verified for reliable Ethernet communication
+* **UART Channel Testing**: Channel 1 verified at 115200 baud operation  
+* **Debug Interface**: UART0 confirmed functional for system diagnostics
+
+=== Pin Assignment Rationale
+
+The current pin assignment prioritizes:
+
+1. **Manufacturing Efficiency**: Ethernet pins grouped to minimize PCB complexity
+2. **Signal Quality**: Custom SPI mapping optimized for the specific PCB layout
+3. **Development Support**: Standard debug interfaces for easy development access
+4. **Future Expansion**: Reserved pins for additional UART channels with PIO implementation
+5. **System Reliability**: Hardware reset and interrupt capabilities for Ethernet controller
+
+=== Compatibility Notes
+
+* **Hardware Dependency**: Pin configuration is hardware-specific and cannot be changed via software
+* **Firmware Binding**: Compiled firmware is tied to this specific pin configuration
+* **Development Tools**: Debug tools must connect to UART0 (GP0/GP1) via USB-CDC for system access
+* **Network Integration**: Ethernet functionality depends on correct custom SPI pin configuration
+* **Channel Expansion**: Additional UART channels require PIO implementation and are currently disabled
+
+=== References
+
+* RP2350 Datasheet: GPIO and Peripheral Pin Mapping
+* ENC28J60 Datasheet: SPI Interface and Reset Requirements  
+* Pico SDK 2.2.0: UART and SPI Configuration Examples
+* Source Code: `include/network/enc28j60_driver.h`, `src/uart/uart_manager.c`
+* VS Code Pico Extension: Development and debugging tools integration


### PR DESCRIPTION
Update ADR-008 to document the current state of hardware pin configuration rather than describing it as a future change.

Key current configuration:
- Debug: UART0 (GP0/GP1) at 115200 baud via USB-CDC
- Channel 1: UART1 (GP4/GP5) at 115200 baud - ENABLED
- Channels 2-3: PIO-based, reserved for future expansion - DISABLED
- Ethernet: ENC28J60 on custom SPI pins GP8-GP13

Removes implementation planning content and focuses on documenting the working system as it currently exists.